### PR TITLE
SAAS-59: v8 support + installer passed by the CICD tool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can find the create scripts in the image here: `/data/digital-factory-data/d
 
 ## Image build
 
-### Specifics for Jahia 8
+### Bypass the installer.jar download and provide your own
 In case a file installer.jar is present in the same folder as the dockerfile during the build, this installer is used instead of the one referenced in the Dockerfile
 
 ### Specifics for Jahia 8

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ You can find the create scripts in the image here: `/data/digital-factory-data/d
 | `XMX`                   | `2048M`        |                                                                                           |
 | `RESTORE_MODULE_STATES` | `true`         | restore modules and their states from database (forced to `false` when database is empty) |
 
+
+## Image build
+
+### Specifics for Jahia 8
+In case a file installer.jar is present in the same folder as the dockerfile during the build, this installer is used instead of the one referenced in the Dockerfile
+
+### Specifics for Jahia 8
+It is necessary to add the parameter `--build-arg INSTALL_FILE_SUFFIX="_v8"` to the build command
+
 In order to use your license file, use _volume_, eg:
 ```bash
 docker run [some docker options here] \

--- a/config_mariadb_v8.xml
+++ b/config_mariadb_v8.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<AutomatedInstallation langpack="eng">
+    <com.izforge.izpack.panels.HelloPanel id="UNKNOWN (com.izforge.izpack.panels.HelloPanel)"/>
+    <com.izforge.izpack.panels.LicencePanel id="UNKNOWN (com.izforge.izpack.panels.LicencePanel)"/>
+    <com.izforge.izpack.panels.TargetPanel id="UNKNOWN (com.izforge.izpack.panels.TargetPanel)">
+        <installpath>/data/jahia</installpath>
+    </com.izforge.izpack.panels.TargetPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="installType">
+        <userInput>
+            <entry key="installation.type" value="advanced"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.PacksPanel id="packsPanel">
+        <pack index="0" name="jahia" selected="true"/>
+        <pack index="1" name="tomcat" selected="false"/>
+    </com.izforge.izpack.panels.PacksPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="dbMode">
+        <userInput>
+            <entry key="dbSettings.mode" value="standalone"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="dbType">
+        <userInput>
+            <entry key="dbSettings.dbms.type" value="mariadb"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="dbTypeMySQL">
+        <userInput/>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="dbSettings">
+        <userInput>
+            <entry key="dbSettings.connection.driver.mariadb" value="org.mariadb.jdbc.Driver"/>
+            <entry key="dbSettings.connection.url.mariadb" value="jdbc:mariadb://${DB_HOST}/${DB_NAME}?useUnicode=true&amp;characterEncoding=UTF-8&amp;useServerPrepStmts=false&amp;useSSL=false"/>
+            <entry key="dbSettings.dbms.createTables" value="false"/>
+            <entry key="dbSettings.connection.username" value="${DB_USER}"/>
+            <entry key="dbSettings.dbms.storeFilesInDB" value="${DS_IN_DB}"/>
+            <entry key="dbSettings.connection.password" value="${DB_PASS}"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="webApp">
+        <userInput>
+            <entry key="jahiaManager.username" value="${JMANAGER_USER}"/>
+            <entry key="jahiaManager.password" value="${JMANAGER_PASSWORD}"/>
+            <entry key="karaf.remoteShell.port" value="8101"/>
+            <entry key="jahia.war.contextName" value=""/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="appServer">
+        <userInput/>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="operatingMode">
+        <userInput>
+            <entry key="operatingMode" value="production"/>
+            <entry key="operatingMode.configure.cluster" value="true"/>
+            <entry key="operatingMode.configure.ldap" value="false"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="ldap">
+        <userInput/>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="cluster">
+        <userInput>
+            <entry key="cluster.processingServer" value="true"/>
+            <entry key="cluster.node.ipAddress" value="&lt;auto&gt;"/>
+            <entry key="cluster.node.port" value="7870"/>
+            <entry key="cluster.node.serverId" value="&lt;auto&gt;"/>
+            <entry key="cluster.hazelcast.port" value="7860"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="superUser">
+        <userInput>
+            <entry key="superUser.password" value="${SUPER_USER_PASSWORD}"/>
+            <entry key="superUser.firstname" value=""/>
+            <entry key="superUser.lastname" value=""/>
+            <entry key="superUser.email" value=""/>
+            <entry key="superUser.preferredLang" value="en"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="mailSettings">
+        <userInput>
+            <entry key="mailSettings.server" value=""/>
+            <entry key="mailSettings.from" value=""/>
+            <entry key="mailSettings.administrator" value=""/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="studioToolSettings">
+        <userInput>
+            <entry key="studioToolSettings.svnPath" value="/usr/bin/svn"/>
+            <entry key="studioToolSettings.mvnPath" value="/opt/apache-maven-${MAVEN_VER}/bin/mvn"/>
+            <entry key="studioToolSettings.gitPath" value="/usr/bin/git"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="externalToolSettings">
+        <userInput>
+            <entry key="dmConfig.imagemagickPath" value="/usr/bin"/>
+            <entry key="dmConfig.officePath" value="/usr/lib/libreoffice"/>
+            <entry key="dmConfig.validate" value="true"/>
+            <entry key="dmConfig.ffmpegPath" value="/usr/bin/ffmpeg"/>
+            <entry key="dmConfig.pdf2swfPath" value=""/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="additionalSettings">
+        <userInput>
+            <entry key="defaultLanguageCode" value="en"/>
+            <entry key="additionalModulesPath" value=""/>
+            <entry key="licensePath" value=""/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="externalizedConfig">
+        <userInput>
+            <entry key="externalizedConfigTargetPath" value="/usr/local/tomcat/conf/digital-factory-config"/>
+            <entry key="data.dir" value="/data/digital-factory-data"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.SummaryPanel id="UNKNOWN (com.izforge.izpack.panels.SummaryPanel)"/>
+    <com.izforge.izpack.panels.ExtendedInstallPanel id="UNKNOWN (com.izforge.izpack.panels.ExtendedInstallPanel)"/>
+    <com.izforge.izpack.panels.ShortcutPanel id="shortcutPanel"/>
+    <com.izforge.izpack.panels.UserInputPanel id="afterInstall">
+        <userInput/>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.ProcessPanel id="UNKNOWN (com.izforge.izpack.panels.ProcessPanel)"/>
+    <com.izforge.izpack.panels.FinishPanel id="UNKNOWN (com.izforge.izpack.panels.FinishPanel)"/>
+</AutomatedInstallation>

--- a/config_postgresql_v8.xml
+++ b/config_postgresql_v8.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<AutomatedInstallation langpack="eng">
+    <com.izforge.izpack.panels.HelloPanel id="UNKNOWN (com.izforge.izpack.panels.HelloPanel)"/>
+    <com.izforge.izpack.panels.LicencePanel id="UNKNOWN (com.izforge.izpack.panels.LicencePanel)"/>
+    <com.izforge.izpack.panels.TargetPanel id="UNKNOWN (com.izforge.izpack.panels.TargetPanel)">
+        <installpath>/data/jahia</installpath>
+    </com.izforge.izpack.panels.TargetPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="installType">
+        <userInput>
+            <entry key="installation.type" value="advanced"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.PacksPanel id="packsPanel">
+        <pack index="0" name="jahia" selected="true"/>
+        <pack index="1" name="tomcat" selected="false"/>
+    </com.izforge.izpack.panels.PacksPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="dbMode">
+        <userInput>
+            <entry key="dbSettings.mode" value="standalone"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="dbType">
+        <userInput>
+            <entry key="dbSettings.dbms.type" value="postgresql"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="dbTypeMySQL">
+        <userInput/>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="dbSettings">
+        <userInput>
+            <entry key="dbSettings.connection.driver.postgresql" value="org.postgresql.jdbc.Driver"/>
+            <entry key="dbSettings.connection.url.postgresql" value="jdbc:postgresql://${DB_HOST}/${DB_NAME}"/>
+            <entry key="dbSettings.dbms.createTables" value="false"/>
+            <entry key="dbSettings.connection.username" value="${DB_USER}"/>
+            <entry key="dbSettings.dbms.storeFilesInDB" value="${DS_IN_DB}"/>
+            <entry key="dbSettings.connection.password" value="${DB_PASS}"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="webApp">
+        <userInput>
+            <entry key="jahiaManager.username" value="${JMANAGER_USER}"/>
+            <entry key="jahiaManager.password" value="${JMANAGER_PASSWORD}"/>
+            <entry key="karaf.remoteShell.port" value="8101"/>
+            <entry key="jahia.war.contextName" value=""/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="appServer">
+        <userInput/>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="operatingMode">
+        <userInput>
+            <entry key="operatingMode" value="production"/>
+            <entry key="operatingMode.configure.cluster" value="true"/>
+            <entry key="operatingMode.configure.ldap" value="false"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="ldap">
+        <userInput/>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="cluster">
+        <userInput>
+            <entry key="cluster.processingServer" value="true"/>
+            <entry key="cluster.node.ipAddress" value="&lt;auto&gt;"/>
+            <entry key="cluster.node.port" value="7870"/>
+            <entry key="cluster.node.serverId" value="&lt;auto&gt;"/>
+            <entry key="cluster.hazelcast.port" value="7860"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="superUser">
+        <userInput>
+            <entry key="superUser.password" value="${SUPER_USER_PASSWORD}"/>
+            <entry key="superUser.firstname" value=""/>
+            <entry key="superUser.lastname" value=""/>
+            <entry key="superUser.email" value=""/>
+            <entry key="superUser.preferredLang" value="en"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="mailSettings">
+        <userInput>
+            <entry key="mailSettings.server" value=""/>
+            <entry key="mailSettings.from" value=""/>
+            <entry key="mailSettings.administrator" value=""/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="studioToolSettings">
+        <userInput>
+            <entry key="studioToolSettings.svnPath" value="/usr/bin/svn"/>
+            <entry key="studioToolSettings.mvnPath" value="/opt/apache-maven-${MAVEN_VER}/bin/mvn"/>
+            <entry key="studioToolSettings.gitPath" value="/usr/bin/git"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="externalToolSettings">
+        <userInput>
+            <entry key="dmConfig.imagemagickPath" value="/usr/bin"/>
+            <entry key="dmConfig.officePath" value="/usr/lib/libreoffice"/>
+            <entry key="dmConfig.validate" value="true"/>
+            <entry key="dmConfig.ffmpegPath" value="/usr/bin/ffmpeg"/>
+            <entry key="dmConfig.pdf2swfPath" value=""/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="additionalSettings">
+        <userInput>
+            <entry key="defaultLanguageCode" value="en"/>
+            <entry key="additionalModulesPath" value=""/>
+            <entry key="licensePath" value=""/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.UserInputPanel id="externalizedConfig">
+        <userInput>
+            <entry key="externalizedConfigTargetPath" value="/usr/local/tomcat/conf/digital-factory-config"/>
+            <entry key="data.dir" value="/data/digital-factory-data"/>
+        </userInput>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.SummaryPanel id="UNKNOWN (com.izforge.izpack.panels.SummaryPanel)"/>
+    <com.izforge.izpack.panels.ExtendedInstallPanel id="UNKNOWN (com.izforge.izpack.panels.ExtendedInstallPanel)"/>
+    <com.izforge.izpack.panels.ShortcutPanel id="shortcutPanel"/>
+    <com.izforge.izpack.panels.UserInputPanel id="afterInstall">
+        <userInput/>
+    </com.izforge.izpack.panels.UserInputPanel>
+    <com.izforge.izpack.panels.ProcessPanel id="UNKNOWN (com.izforge.izpack.panels.ProcessPanel)"/>
+    <com.izforge.izpack.panels.FinishPanel id="UNKNOWN (com.izforge.izpack.panels.FinishPanel)"/>
+</AutomatedInstallation>


### PR DESCRIPTION
Added support of Jahia v8
Added support of provided installer.jar, instead of forcing the download from a URL (useful when the URL is protected by an authentication)