### PR TITLE
SAAS-59: allows the CICD to provide optional modules to be embedded in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,10 @@ RUN printf "Start Jahia's installation...\n" \
 ADD $MODULES_BASE_URL/healthcheck/$HEALTHCHECK_VER/healthcheck-$HEALTHCHECK_VER.jar \
         $FACTORY_DATA/modules/healthcheck-$HEALTHCHECK_VER.jar
 
+COPY optional_modules* /tmp
+## allows the Docker build to continue if no modules were provided
+RUN mv /tmp/*.jar /data/digital-factory-data/modules || true
+RUN ls /data/digital-factory-data/modules
 
 EXPOSE 8080
 EXPOSE 7860

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,6 @@ ADD $MODULES_BASE_URL/healthcheck/$HEALTHCHECK_VER/healthcheck-$HEALTHCHECK_VER.
 COPY optional_modules* /tmp
 ## allows the Docker build to continue if no modules were provided
 RUN mv /tmp/*.jar /data/digital-factory-data/modules || true
-RUN ls /data/digital-factory-data/modules
 
 EXPOSE 8080
 EXPOSE 7860


### PR DESCRIPTION
SAAS-59: allows the CICD to provide optional modules to be embedded in image