### PR TITLE
SAAS-165 set healthchech 2.0.3 as new default version for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
         default: "true"
       healthcheck_ver:
         type: string
-        default: "2.0.2"
+        default: "2.0.3"
     steps:
       - setup_remote_docker
       - checkout


### PR DESCRIPTION
https://jira.jahia.org/browse/SAAS-165