### PR TITLE
SAAS-191: allow for CTRL+C in attached mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,4 +148,4 @@ HEALTHCHECK --interval=30s \
                     exit 1; \
                 fi
 
-CMD /entrypoint.sh
+CMD ["/entrypoint.sh"]


### PR DESCRIPTION
https://jira.jahia.org/browse/SAAS-191
the CMD XXXX command executes a bash -c command that intercepts the signal issue by CTRL+C, while CMD ["XXXXX"] does kill the process.