### PR TITLE
SAAS-261: fix datastore permissions (again)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -140,9 +140,8 @@ RUN groupadd -g 999 $C_GROUP
 RUN useradd -r -u 999 -g $C_GROUP $C_USER -d $CATALINA_BASE/temp -m
 RUN chown -R $C_USER: $CATALINA_BASE $FACTORY_DATA \
     && chown $C_USER: /entrypoint.sh
-RUN $DS_IN_DB && ( mkdir -p $DS_PATH \
-    && chown -R $C_USER:$C_GROUP $DS_PATH ) \
-    || true
+RUN $DS_IN_DB || ( mkdir -p $DS_PATH \
+    && chown -R $C_USER:$C_GROUP $DS_PATH )
 USER $C_USER
 
 EXPOSE 8080


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/SAAS-261

## Description

Fixing a dumb issue coming from my last PR (was creating the /datastore folder if DS_IN_DB was true instead of false)